### PR TITLE
fix require path to exec.rb

### DIFF
--- a/exec.rb
+++ b/exec.rb
@@ -1,13 +1,9 @@
 #!/usr/bin/env ruby
-require './program'
-require './plus'
-require './constant'
-require './arithmeticOp'
 
-
-# Dir[File.expand_path('./lib', __FILE__) << '/*.rb'].each do |file|
-#   require file
-# end
+# Libraryの読み込み
+Dir[File.expand_path('../lib', __FILE__) << '/*.rb'].each do |file|
+  require file
+end
 
 # p = Program.new
 

--- a/lib/arithmeticOp.rb
+++ b/lib/arithmeticOp.rb
@@ -1,3 +1,3 @@
-require './operator'
+require File.dirname(__FILE__) + '/operator'
 class ArithmeticOp < Operator
 end

--- a/lib/assignment.rb
+++ b/lib/assignment.rb
@@ -1,6 +1,6 @@
-require './instruction'
-require './variable'
-require './expression'
+require File.dirname(__FILE__) + '/instruction'
+require File.dirname(__FILE__) + '/variable'
+require File.dirname(__FILE__) + '/expression'
 
 class Assignment < Instruction
 

--- a/lib/binary.rb
+++ b/lib/binary.rb
@@ -1,5 +1,5 @@
-require './expression'
-require './operator'
+require File.dirname(__FILE__) + '/expression'
+require File.dirname(__FILE__) + '/operator'
 
 class Binary < Expression
 

--- a/lib/compound.rb
+++ b/lib/compound.rb
@@ -1,4 +1,4 @@
-require './instruction'
+require File.dirname(__FILE__) + '/instruction'
 
 class Compound < Instruction
 end

--- a/lib/conditional.rb
+++ b/lib/conditional.rb
@@ -1,5 +1,5 @@
-require './instruction'
-require './expression'
+require File.dirname(__FILE__) + '/instruction'
+require File.dirname(__FILE__) + '/expression'
 
 
 class Conditional < Instruction

--- a/lib/constant.rb
+++ b/lib/constant.rb
@@ -1,4 +1,4 @@
-require './expression'
+require File.dirname(__FILE__) + '/expression'
 
 class Constant < Expression
 

--- a/lib/divide.rb
+++ b/lib/divide.rb
@@ -1,4 +1,4 @@
-require './arithmeticOp'
+require File.dirname(__FILE__) + '/arithmeticOp'
 
 class Divide < ArithmeticOp
 end

--- a/lib/minus.rb
+++ b/lib/minus.rb
@@ -1,4 +1,4 @@
-require './arithmeticOp'
+require File.dirname(__FILE__) + '/arithmeticOp'
 
 class Minus < ArithmeticOp
 end

--- a/lib/plus.rb
+++ b/lib/plus.rb
@@ -1,4 +1,4 @@
-require './arithmeticOp'
+require File.dirname(__FILE__) + '/arithmeticOp'
 
 class Plus < ArithmeticOp
 

--- a/lib/program.rb
+++ b/lib/program.rb
@@ -1,4 +1,4 @@
-require './instruction'
+require File.dirname(__FILE__) + '/instruction'
 
 class Program
   private

--- a/lib/skip.rb
+++ b/lib/skip.rb
@@ -1,4 +1,4 @@
-require './instruction'
+require File.dirname(__FILE__) + '/instruction'
 
 class Skip < Instruction
 end

--- a/lib/surplus.rb
+++ b/lib/surplus.rb
@@ -1,4 +1,4 @@
-require './arithmeticOp'
+require File.dirname(__FILE__) + '/arithmeticOp'
 
 class Surplus < ArithmeticOp
 end

--- a/lib/times.rb
+++ b/lib/times.rb
@@ -1,4 +1,4 @@
-require './arithmeticOp'
+require File.dirname(__FILE__) + '/arithmeticOp'
 
 class Times < ArithmeticOp
 end

--- a/lib/variable.rb
+++ b/lib/variable.rb
@@ -1,4 +1,4 @@
-require './expression'
+require File.dirname(__FILE__) + '/expression'
 
 class Variable < Expression
 


### PR DESCRIPTION
- requireのパスを修正
- 実行ファイル (exec.rb)の場所をroot直下に変更
