### PR TITLE
move abstract_syntax_lists /lib from /

### DIFF
--- a/lib/abstract_syntax_lists.rb
+++ b/lib/abstract_syntax_lists.rb
@@ -1,6 +1,6 @@
 # ライブラリの読み込み
 require 'i18n'
-I18n.load_path = Dir[File.expand_path('../config/locales', __FILE__) << '/*.yml']
+I18n.load_path = Dir[File.expand_path('../../config/locales', __FILE__) << '/*.yml']
 
 class AbstractSyntaxLists
 
@@ -10,7 +10,7 @@ class AbstractSyntaxLists
 
     # 抽象文法のリストを取得
     abstract_syntax = YAML.load_file(File.dirname(__FILE__) +
-                                    "/config/locales/as.#{I18n.locale.to_s}.yml")
+                                    "/../config/locales/as.#{I18n.locale.to_s}.yml")
 
     # 抽象文法のクラス一覧を取得
     class_all_lists = abstract_syntax[I18n.locale.to_s].map do |key, value|

--- a/locale_test.rb
+++ b/locale_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require './abstract_syntax_lists'
+require './lib/abstract_syntax_lists'
 
 # $ bundle exec ruby locales_test.rb
 puts AbstractSyntaxLists.create(:ja)

--- a/spec/abstract_syntax_lists_spec.rb
+++ b/spec/abstract_syntax_lists_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
-require_relative '../abstract_syntax_lists'
-require 'i18n'
+require_relative '../lib/abstract_syntax_lists'
 
 describe 'AbstractSyntaxLists' do
 


### PR DESCRIPTION
- abstract_syntax_lists.rb の場所を `/` から `/lib` に変更
