### PR TITLE
fix locale path from abstract syntax lists

### DIFF
--- a/lib/ootalk/abstract_syntax_lists.rb
+++ b/lib/ootalk/abstract_syntax_lists.rb
@@ -6,8 +6,8 @@ module OoTalk
   class AbstractSyntaxLists
     def self.create(locale = :en)
       # 言語設定
-      I18n.load_path = Dir[File.expand_path('../../config/locales', __FILE__) << '/*.yml']
-      I18n.available_locales = [:en, :ja, :cn, :vi]
+      I18n.load_path = Dir[File.expand_path('../../../config/locales', __FILE__) << '/*.yml']
+      I18n.available_locales = [:en, :ja, :cn]
       I18n.enforce_available_locales = true
       I18n.default_locale = :en
 


### PR DESCRIPTION
- pathが変わったので修正
